### PR TITLE
Match email addresses case-insensitively

### DIFF
--- a/lib/xema/format.ex
+++ b/lib/xema/format.ex
@@ -166,7 +166,7 @@ defmodule Xema.Format do
     \.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:
     (?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\
     [\x01-\x09\x0b\x0c\x0e-\x7f])+)\])
-  >x
+  >ix
   @spec email?(String.t()) :: boolean
   def email?(string) when is_binary(string), do: Regex.match?(@email, string)
 


### PR DESCRIPTION
Uppercase letters can occur in an email address according to RFC 5322. The regexp should ignore case.