### PR TITLE
Domain or subdomain could start with a digit

### DIFF
--- a/lib/xema/format.ex
+++ b/lib/xema/format.ex
@@ -211,7 +211,7 @@ defmodule Xema.Format do
   """
   @hostname ~r/
       (?(DEFINE)
-        (?<sub_domain> (?:[a-z][-a-z\d]{0,62}) )
+        (?<sub_domain> (?:[a-z\d][-a-z\d]{0,62}) )
       )
       ^(?&sub_domain)(?:\.(?&sub_domain))*$
     /xi

--- a/test/json_schema_test_suite/draft4/optional/format_test.exs
+++ b/test/json_schema_test_suite/draft4/optional/format_test.exs
@@ -66,6 +66,10 @@ defmodule JsonSchemaTestSuite.Draft4.Optional.FormatTest do
       assert valid?(schema, "http://foo.bar/?baz=qux#quux")
     end
 
+    test "a valid URL with domain starts with a digit", %{schema: schema} do
+      assert valid?(schema, "https://9gag.com/")
+    end
+
     test "a valid URL with anchor tag and parantheses", %{schema: schema} do
       assert valid?(schema, "http://foo.com/blah_(wikipedia)_blah#cite-1")
     end


### PR DESCRIPTION
Despite of RFC 1034 domain or subdomain could start with a digit. For example, 9gag.com
So, URI validation does not work properly.