### PR TITLE
Handle inline_refs for JsonSchema refs

### DIFF
--- a/lib/xema/behaviour.ex
+++ b/lib/xema/behaviour.ex
@@ -188,6 +188,9 @@ defmodule Xema.Behaviour do
         {ref, %Schema{} = schema} ->
           {ref, inline_refs(circulars, xema, nil, schema)}
 
+        {ref, %{ schema: %Schema{} = schema }} ->
+          {ref, inline_refs(circulars, xema, nil, schema)}
+
         {_ref, _xema} = ref ->
           ref
       end)


### PR DESCRIPTION
I may be misunderstanding or misusing the library but I got stuck in a situation where my refs were all JsonXema structs rather than Xema.Schema structs so the inline process was failing to resolve the refs correctly.

For more context, I have written a custom Loader to work with ETS and the schemas I'm using will have a chain of references. The library seems to handle it perfectly but the result was slightly different than expected. After adding this case, my entire scenario works fine.

Since I don't fully understand how it happened, I didn't have time to write a test for it. Hopefully it'll make sense to somebody and they can add to my commit.