### PR TITLE
When converting from a json schema always set keys to :strings

### DIFF
--- a/lib/xema.ex
+++ b/lib/xema.ex
@@ -270,7 +270,8 @@ defmodule Xema do
       %Xema{schema:
         %Xema.Schema{
           properties: %{"foo" => %Xema.Schema{type: :integer}},
-          type: :map
+          type: :map,
+          keys: :strings
         }
       }
 

--- a/lib/xema/json_schema.ex
+++ b/lib/xema/json_schema.ex
@@ -73,7 +73,7 @@ defmodule Xema.JsonSchema do
       ...>   "properties" => %{"foo" => %{"type" => "integer"}}
       ...> }
       iex> Xema.JsonSchema.to_xema(schema)
-      {:map, [properties: %{"foo" => :integer}]}
+      {:map, [keys: :strings, properties: %{"foo" => :integer}]}
 
       iex> Xema.JsonSchema.to_xema(%{"type" => "integer", "foo" => "bar"}, atom: :force)
       {:integer, [foo: "bar"]}
@@ -98,8 +98,14 @@ defmodule Xema.JsonSchema do
     {type, json} = type(json)
 
     case Enum.empty?(json) do
-      true -> type
-      false -> {type, schema(json, opts)}
+      true ->
+        type
+
+      false ->
+        case type do
+          :map -> {type, schema(Map.put_new(json, "keys", :strings), opts)}
+          _ -> {type, schema(json, opts)}
+        end
     end
   end
 

--- a/test/xema/from_json_schema_test.exs
+++ b/test/xema/from_json_schema_test.exs
@@ -32,7 +32,8 @@ defmodule Xema.FromJsonSchemaTest do
                  refs: %{},
                  schema: %Schema{
                    properties: %{"foo" => %Schema{type: :integer}},
-                   type: :map
+                   type: :map,
+                   keys: :strings
                  }
                }
     end
@@ -56,7 +57,8 @@ defmodule Xema.FromJsonSchemaTest do
                  schema: %Xema.Schema{
                    data: %{zonk: "bla"},
                    properties: %{"foo" => %Xema.Schema{type: :integer}},
-                   type: :map
+                   type: :map,
+                   keys: :strings
                  }
                }
     end
@@ -85,6 +87,28 @@ defmodule Xema.FromJsonSchemaTest do
                refs: %{},
                schema: %Xema.Schema{format: :unsupported}
              }
+    end
+
+    test "can cast from a json schema" do
+      json_schema =
+        """
+          {
+            "additionalProperties": false,
+            "properties": {
+              "foo": { "type": "string" },
+              "bar": { "items": { "type": "string" }, "type": "array" },
+              "baz": { "type": "object", "properties": {"prop": { "type": "string" } } }
+            },
+            "required": ["foo", "bar"],
+            "type": "object"
+          }
+        """
+        |> Jason.decode!()
+        |> Xema.from_json_schema()
+
+      data = %{"foo" => "somestring", "bar" => ["a", "b"]}
+      assert Xema.validate(json_schema, data) == :ok
+      assert Xema.cast(json_schema, data) == {:ok, data}
     end
   end
 end

--- a/test/xema/json_schema_test.exs
+++ b/test/xema/json_schema_test.exs
@@ -42,7 +42,7 @@ defmodule Xema.JsonSchemaTest do
     }
     """
 
-    assert to_xema(json_schema) == {:map, properties: %{"number" => :number}}
+    assert to_xema(json_schema) == {:map, keys: :strings, properties: %{"number" => :number}}
   end
 
   test "none schema" do


### PR DESCRIPTION
This allows proper casting of data with schemas originated from a json schema.