### PR TITLE
fix boolean values in custom data map

### DIFF
--- a/lib/xema.ex
+++ b/lib/xema.ex
@@ -477,6 +477,8 @@ defmodule Xema do
     end
   end
 
+  defp maybe_schema(boolean) when is_boolean(boolean), do: boolean
+
   defp maybe_schema(atom) when is_atom(atom) do
     case atom in Schema.types() do
       true -> schema(atom)

--- a/lib/xema.ex
+++ b/lib/xema.ex
@@ -477,6 +477,7 @@ defmodule Xema do
     end
   end
 
+  defp maybe_schema(nil), do: nil
   defp maybe_schema(boolean) when is_boolean(boolean), do: boolean
 
   defp maybe_schema(atom) when is_atom(atom) do

--- a/test/xema/data_test.exs
+++ b/test/xema/data_test.exs
@@ -7,6 +7,9 @@ defmodule Xema.DataTest do
 
   describe "custom data: " do
     test "additional data goes to the data map" do
+      schema = Xema.new({:map, foo: nil})
+      assert schema.schema.data == %{foo: nil}
+
       schema = Xema.new({:map, foo: true})
       assert schema.schema.data == %{foo: true}
 

--- a/test/xema/data_test.exs
+++ b/test/xema/data_test.exs
@@ -7,6 +7,12 @@ defmodule Xema.DataTest do
 
   describe "custom data: " do
     test "additional data goes to the data map" do
+      schema = Xema.new({:map, foo: true})
+      assert schema.schema.data == %{foo: true}
+
+      schema = Xema.new({:map, foo: false})
+      assert schema.schema.data == %{foo: false}
+
       schema = Xema.new({:map, foo: 3})
       assert schema.schema.data == %{foo: 3}
 


### PR DESCRIPTION
Fixes https://github.com/hrzndhrn/xema/issues/165

`true, false` are atoms in Elixir, and need to be matched before the `defp maybe_schema(atom) when is_atom(atom)` function.
Also fixed for `nil` values.