### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
   ```elixir
   defmoudle MyApp.Schemas do
-    use Xemae, multi: true, default: :s1
+    use Xema, multi: true, default: :s1
 
     xema :s1 do
       ...

--- a/lib/xema/builder.ex
+++ b/lib/xema/builder.ex
@@ -257,7 +257,7 @@ defmodule Xema.Builder do
         Example:
 
         defmoudle MyApp.Schemas do
-          use Xemae, multi: true, default: :s1
+          use Xema, multi: true, default: :s1
 
           xema :s1 do
             ...


### PR DESCRIPTION
Title & diff say it all, `use Xemae` was present in a couple of examples instead of `use Xema`.