### PR TITLE
Make it working on Elixir 1.14

### DIFF
--- a/lib/xema/ref.ex
+++ b/lib/xema/ref.ex
@@ -123,12 +123,13 @@ end
 
 defimpl Inspect, for: Xema.Ref do
   def inspect(schema, opts) do
-    map =
+    fields =
       schema
       |> Map.from_struct()
       |> Enum.filter(fn {_, val} -> !is_nil(val) end)
-      |> Enum.into(%{})
 
-    Inspect.Map.inspect(map, "Xema.Ref", opts)
+    infos = for {field, _value} <- fields, do: %{field: field}
+
+    Inspect.Map.inspect(Enum.into(fields, %{}), "Xema.Ref", infos, opts)
   end
 end

--- a/lib/xema/schema.ex
+++ b/lib/xema/schema.ex
@@ -413,7 +413,7 @@ end
 
 defimpl Inspect, for: Xema.Schema do
   def inspect(schema, opts) do
-    map =
+    fields =
       schema
       |> Map.from_struct()
       |> Map.update!(
@@ -426,6 +426,8 @@ defimpl Inspect, for: Xema.Schema do
       |> Enum.filter(fn {_, val} -> !is_nil(val) end)
       |> Enum.into(%{})
 
-    Inspect.Map.inspect(map, "Xema.Schema", opts)
+    infos = for {field, _value} <- fields, do: %{field: field}
+
+    Inspect.Map.inspect(Enum.into(fields, %{}), "Xema.Schema", infos, opts)
   end
 end

--- a/test/xema/schema_test.exs
+++ b/test/xema/schema_test.exs
@@ -8,7 +8,7 @@ defmodule Xema.SchemaTest do
 
   describe "new/1" do
     test "raises an error for an invalid keyword" do
-      message = "key :foo not found in: %Xema.Schema{}"
+      message = ~r/^key :foo not found/
 
       assert_raise(KeyError, message, fn ->
         Schema.new(type: :any, foo: :foo)
@@ -39,27 +39,27 @@ defmodule Xema.SchemaTest do
       xema = Xema.new({:list, items: [:integer]})
 
       assert inspect(xema) ==
-               "%Xema{refs: %{}, schema: " <>
+               "%Xema{schema: " <>
                  "%Xema.Schema{items: " <>
-                 "[%Xema.Schema{type: :integer}], " <> "type: :list}}"
+                 "[%Xema.Schema{type: :integer}], " <> "type: :list}, refs: %{}}"
     end
 
     test "any schema" do
       xema = Xema.new(items: [:integer])
 
       assert inspect(xema) ==
-               "%Xema{refs: %{}, schema: " <>
-                 "%Xema.Schema{items: " <> "[%Xema.Schema{type: :integer}]}}"
+               "%Xema{schema: " <>
+                 "%Xema.Schema{items: " <> "[%Xema.Schema{type: :integer}]}, refs: %{}}"
     end
 
     test "schema with ref" do
       xema = Xema.new({:map, properties: %{num: {:ref, "#"}}})
 
       assert inspect(xema) ==
-               "%Xema{refs: %{}, schema: " <>
+               "%Xema{schema: " <>
                  "%Xema.Schema{properties: " <>
                  "%{num: %Xema.Schema{ref: " <>
-                 "%Xema.Ref{pointer: \"#\"}}}, " <> "type: :map}}"
+                 "%Xema.Ref{pointer: \"#\"}}}, " <> "type: :map}, refs: %{}}"
     end
   end
 


### PR DESCRIPTION
* Use `Inspect.Map.inspect/4` instead of `Inspect.Map.inspect/3` in `Xema.Schema` and `Xema.Ref`.
* Move `refs` field to the end of inspected string. The Elixir 1.14 sort field from `defstruct` key.